### PR TITLE
fix psr-4 test name errors

### DIFF
--- a/laravel/tests/Unit/EvaluateGenerateTimeIntervalsTest.php
+++ b/laravel/tests/Unit/EvaluateGenerateTimeIntervalsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\ScheduleParser;
 use App\EvaluationParser;
 
-class EvaluateGenerateTimeIntervals extends TestCase
+class EvaluateGenerateTimeIntervalsTest extends TestCase
 {
     /**
      * A basic test example.

--- a/laravel/tests/Unit/GenerateSendNotificationForOverwriteTest.php
+++ b/laravel/tests/Unit/GenerateSendNotificationForOverwriteTest.php
@@ -9,7 +9,7 @@ use App\ScheduleParser;
 use App\Option;
 use App\Http\Controllers\ScheduleDataController;
 
-class GenerateSendNotificationForOverwrite extends TestCase
+class GenerateSendNotificationForOverwriteTest extends TestCase
 {
     public function testOption1ForTestResidentHasOneValue()
     {

--- a/laravel/tests/Unit/MapRotationEvaluationTest.php
+++ b/laravel/tests/Unit/MapRotationEvaluationTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class MapRotationEvaluation extends TestCase
+class MapRotationEvaluationTest extends TestCase
 {
     /**
      * A basic test to check that the residents table has values

--- a/laravel/tests/Unit/ResidentFillsLearningObjectiveTest.php
+++ b/laravel/tests/Unit/ResidentFillsLearningObjectiveTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentFillsLearningObjective extends TestCase
+class ResidentFillsLearningObjectiveTest extends TestCase
 {
     /**
      * Test to check a certain user exists

--- a/laravel/tests/Unit/ResidentSelectDayTest.php
+++ b/laravel/tests/Unit/ResidentSelectDayTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentConfirmationFlow extends TestCase
+class ResidentSelectDayTest extends TestCase
 {
     public function testFlow()
     {

--- a/laravel/tests/Unit/ResidentSelectMilestoneTest.php
+++ b/laravel/tests/Unit/ResidentSelectMilestoneTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentSelectMilestone extends TestCase
+class ResidentSelectMilestoneTest extends TestCase
 {
     /**
      * Test to check a certain user exists

--- a/laravel/tests/Unit/ResidentSubmitPreferenceTest.php
+++ b/laravel/tests/Unit/ResidentSubmitPreferenceTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentSubmitsPreferenceText extends TestCase
+class ResidentSubmitPreferenceTest extends TestCase
 {
     // Resident selects no preferences
     public function testNoPref()

--- a/laravel/tests/Unit/ResidentSubmitsFromOneScreenTest.php
+++ b/laravel/tests/Unit/ResidentSubmitsFromOneScreenTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentSubmitsFromOneScreen extends TestCase
+class ResidentSubmitsFromOneScreenTest extends TestCase
 {
     /**
      * Test to check a certain user exists

--- a/laravel/tests/Unit/ResidentSubmitsSelectionTextTest.php
+++ b/laravel/tests/Unit/ResidentSubmitsSelectionTextTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentSubmitsSelectionText extends TestCase
+class ResidentSubmitsSelectionTextTest extends TestCase
 {
     public function testOptionTableHasSubmissionOfPref1()
     {

--- a/laravel/tests/Unit/ResidentViewPreferencesTest.php
+++ b/laravel/tests/Unit/ResidentViewPreferencesTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentViewPreferences extends TestCase
+class ResidentViewPreferencesTest extends TestCase
 {
     /**
      * Test to check a certain user exists

--- a/laravel/tests/Unit/ResidentViewTableTest.php
+++ b/laravel/tests/Unit/ResidentViewTableTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ResidentViewTable extends TestCase
+class ResidentViewTableTest extends TestCase
 {
     public function testViewScheduleDataHasStartTime()
     {

--- a/laravel/tests/Unit/RetrieveScheduleRotationTest.php
+++ b/laravel/tests/Unit/RetrieveScheduleRotationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\MedhubController;
 
-class RetrieveScheduleRotation extends TestCase
+class RetrieveScheduleRotationTest extends TestCase
 {
     /**
      * A basic test to check the connection to medhub api with TestPOST call

--- a/laravel/tests/Unit/SaveMedHubInfoTest.php
+++ b/laravel/tests/Unit/SaveMedHubInfoTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\MedhubController;
 
-class SaveMedHubInfo extends TestCase
+class SaveMedHubInfoTest extends TestCase
 {
     /**
      * A basic test example.

--- a/laravel/tests/Unit/ScheduleDataTableTest.php
+++ b/laravel/tests/Unit/ScheduleDataTableTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\ScheduleDataController;
 
-class ScheduleDataControllerTestForScheduleTable extends TestCase
+class ScheduleDataTableTest extends TestCase
 {
     public function testScheduleDataHasStartTime()
     {

--- a/laravel/tests/Unit/ScheduleFileExistsandIsTxtTest.php
+++ b/laravel/tests/Unit/ScheduleFileExistsandIsTxtTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Http\Controllers\AdminController;
 
-class ScheduleFileExistsandIsTxt extends TestCase
+class ScheduleFileExistsandIsTxtTest extends TestCase
 {
     /**
      * Test if the schedule file exists

--- a/laravel/tests/Unit/SendEvalTest.php
+++ b/laravel/tests/Unit/SendEvalTest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Resident;
 
-class SendEval extends TestCase
+class SendEvalTest extends TestCase
 {
     /**
      * A basic test example.

--- a/laravel/tests/Unit/TableTest.php
+++ b/laravel/tests/Unit/TableTest.php
@@ -1,12 +1,9 @@
 <?php
 
-namespace Tests;
+namespace Tests\Unit;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
-use App\Http\Controllers\Controller;
 
 use App\Resident;
 use App\ScheduleData;
@@ -14,7 +11,7 @@ use App\Attending;
 use App\Admin;
 use App\Option;
 
-class ExampleTest extends TestCase
+class TableTest extends TestCase
 {
     public function testDBAdminXY()
     {

--- a/laravel/tests/Unit/TabletPhoneTest.php
+++ b/laravel/tests/Unit/TabletPhoneTest.php
@@ -11,7 +11,7 @@ use App\Option;
 use App\EvaluationParser;
 use App\Http\Controllers\MedhubController;
 
-class TablePhoneTest extends TestCase
+class TabletPhoneTest extends TestCase
 {
     // Resize the screen size and check if the navigation bar become a dropdown menu
     public function testResizeNavigationToDropDown()


### PR DESCRIPTION
psr-4 expects class names to match file names.

makes composer emit WAY fewer errors when installing/upgrading packages.