### PR TITLE
No more hardcoded email address and add env to email subject

### DIFF
--- a/laravel/app/EvaluationParser.php
+++ b/laravel/app/EvaluationParser.php
@@ -90,7 +90,7 @@ class EvaluationParser extends Model
             }
         }
         //send emails for all users not added 
-        self::notifyForAllFailedUsers($residentsFailedAdding, $attendingsFailedAdding, "Melanie", "ferguson.881@osu.edu");
+        self::notifyForAllFailedUsers($residentsFailedAdding, $attendingsFailedAdding, config('mail.admin.name'), config('mail.admin.email'));
         fclose($fp);
     }
 
@@ -465,11 +465,11 @@ class EvaluationParser extends Model
 
     public function sendEmailForFailedUsers($toName, $toEmail, $dataRows)
     {
-        $subject = 'REMODEL: Resident/Attending Needs to be Added';
+        $subject = '(' . config('app.env'). ') REMODEL: Resident/Attending Needs to be Added';
         $data = array('name' => $toName, 'dataRows' => $dataRows);
         Mail::send('emails.mail_table', $data, function ($message) use ($toName, $toEmail, $subject) {
             $message->to($toEmail, $toName)->subject($subject);
-            $message->from('OhioStateAnesthesiology@gmail.com');
+            $message->from(config('mail.username'));
         });
     }
 }

--- a/laravel/app/Http/Controllers/PagesController.php
+++ b/laravel/app/Http/Controllers/PagesController.php
@@ -246,7 +246,7 @@ class PagesController extends Controller
 
         Mail::send('emails.contact', $data, function($message) use ($data){
             $message->from($data['email']);
-            $message->to('David.Stahl@osumc.edu');
+            $message->to(config('mail.admin.email'));
             $message->subject($data['subject']);
         });
 

--- a/laravel/app/Http/Controllers/ScheduleDataController.php
+++ b/laravel/app/Http/Controllers/ScheduleDataController.php
@@ -490,14 +490,14 @@ class ScheduleDataController extends Controller
 			$choice = $choice." 3";
 		}
 
-		$subject = 'REMODEL: Resident Preference '.$choice.' Overwritten for '.$date;
+		$subject = '(' . config('app.env'). ') REMODEL: Resident Preference '.$choice.' Overwritten for '.$date;
 		$body = "Resident $residentName has overwritten OR preferences  ".$choice." for ".$date.". New preferences are now viewable on REMODEL website.";
 		$heading = "Resident $residentName has overwritten OR preference ".$choice;
         $data = array('name'=>$toName, 'heading'=>$heading, 'body'=>$body);
 
         Mail::send('emails.mail', $data, function($message) use ($toName, $toEmail, $subject) {
             $message->to($toEmail, $toName)->subject($subject);
-            $message->from('OhioStateAnesthesiology@gmail.com');
+            $message->from(config('mail.username'));
         });
 		return true;
     }

--- a/laravel/app/ScheduleParser.php
+++ b/laravel/app/ScheduleParser.php
@@ -182,14 +182,14 @@ class ScheduleParser extends Model
     public function notifySelectNewPreferences($toName, $toEmail, $date)
     {
         Log::info('send email');
-        $subject = 'REMODEL: Please select new preferences for date '.$date;
+        $subject = '(' . config('app.env'). ') REMODEL: Please select new preferences for date '.$date;
         $body = 'Your previous preferences for date '.$date.' were deleted because the schedule is updated. Please select new preferences on REMODEL website.';
         $heading = 'Please select new preferences for date '.$date;
         $data = array('name'=>$toName, 'heading'=>$heading, 'body'=>$body);
 
         Mail::send('emails.mail', $data, function($message) use ($toName, $toEmail, $subject) {
             $message->to($toEmail, $toName)->subject($subject);
-            $message->from('OhioStateAnesthesiology@gmail.com');
+            $message->from(config('mail.username'));
         });
     }
 

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -121,4 +121,9 @@ return [
         ],
     ],
 
+    'admin' => [
+        'name' => env('ADMIN_PRIMARY_NAME', 'Admin'),
+        'email' => env('ADMIN_PRIMARY_EMAIL', 'Ohiostateanesthesiology@gmail.com'),
+    ],
+
 ];


### PR DESCRIPTION
- extracted hardcoded email address and use config variable instead
- added tag to email subject to contain the app environment (e.g. testing, development, production)
- Note: need to update the env file on the test, dev, and production server to ensure correct env name, admin email, and mail_username